### PR TITLE
workflows: Unify naming of workflows and their tasks

### DIFF
--- a/.github/workflows/build-package-artifacts.yml
+++ b/.github/workflows/build-package-artifacts.yml
@@ -85,7 +85,7 @@ jobs:
           nrfutil install sdk-manager
           nrfutil sdk-manager install ${{ env.SDK_VERSION }}
 
-      - name: Build zephyrdoom artifacts
+      - name: Build artifacts
         run: |
           nrfutil sdk-manager toolchain launch \
           --ncs-version ${{ env.TOOLCHAIN_VERSION }} -- \
@@ -98,29 +98,29 @@ jobs:
             --pristine \
             --board ${{ env.BOARD_TARGET }} \
             -- -DNCS_TOOLCHAIN_VERSION=NONE \
-            2>&1 | tee zephyrdoom-build-${{ env.SDK_VERSION }}-${{ github.run_number }}.log'
+            2>&1 | tee build-${{ env.SDK_VERSION }}-${{ github.run_number }}.log'
 
       - name: Rename zephyrdoom artifacts
         run: |
           cp "${{ github.workspace }}/zephyrdoom/build/zephyr/merged.hex" \
-          "${{ github.workspace }}/zephyrdoom-merged-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex"
+          "${{ github.workspace }}/merged-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex"
           cp "${{ github.workspace }}/zephyrdoom/build/zephyr/merged_domains.hex" \
-          "${{ github.workspace }}/zephyrdoom-merged-domains-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex"
+          "${{ github.workspace }}/merged-domains-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex"
           cp "${{ github.workspace }}/zephyrdoom/build/zephyr/zephyr.hex" \
-          "${{ github.workspace }}/zephyrdoom-zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex"
+          "${{ github.workspace }}/zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex"
           cp "${{ github.workspace }}/zephyrdoom/build/zephyr/zephyr.elf" \
-          "${{ github.workspace }}/zephyrdoom-zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.elf"
+          "${{ github.workspace }}/zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.elf"
           cp "${{ github.workspace }}/zephyrdoom/build/zephyr/zephyr.map" \
-          "${{ github.workspace }}/zephyrdoom-zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.map"
+          "${{ github.workspace }}/zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.map"
 
-      - name: Upload zephyrdoom artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: zephyrdoom-build-${{ env.SDK_VERSION }}-${{ env.BOARD_TARGET }}-${{ github.run_number }}
+          name: build-${{ env.SDK_VERSION }}-${{ env.BOARD_TARGET }}-${{ github.run_number }}
           path: |
-            zephyrdoom-merged-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex
-            zephyrdoom-merged-domains-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex
-            zephyrdoom-zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex
-            zephyrdoom-zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.elf
-            zephyrdoom-zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.map
-            zephyrdoom-build-${{ env.SDK_VERSION }}-${{ github.run_number }}.log
+            merged-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex
+            merged-domains-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex
+            zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.hex
+            zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.elf
+            zephyr-${{ env.SDK_VERSION }}-${{ github.run_number }}.map
+            build-${{ env.SDK_VERSION }}-${{ github.run_number }}.log

--- a/.github/workflows/cppcheck-verification.yml
+++ b/.github/workflows/cppcheck-verification.yml
@@ -1,5 +1,5 @@
 ---
-name: Cppcheck linter
+name: Cppcheck verification
 run-name: >
   ${{ github.workflow }} — Triggered by
   ${{ github.actor }} on ${{ github.ref_name }}
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   cppcheck-lint:
-    name: Run cppcheck linter
+    name: Run Cppcheck verification
     runs-on: ubuntu-24.04
 
     steps:
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y \
           cppcheck
 
-      - name: Run cppcheck command for zephyrdoom source files
+      - name: Run cppcheck command
         run: |
           cppcheck \
           --force \
@@ -42,17 +42,17 @@ jobs:
           -I "${{ github.workspace }}/zephyrdoom/src/config/" \
           -I "${{ github.workspace }}/zephyrdoom/src/doom/" \
           "${{ github.workspace }}/zephyrdoom/src" \
-          2>&1 | tee zephyrdoom-cppcheck-${{ github.run_number }}.log
+          2>&1 | tee cppcheck-${{ github.run_number }}.log
 
-      - name: Analyze logs of zephyrdoom source files
+      - name: Analyze cppcheck logs
         run: |
           "${{ github.workspace }}/.github/scripts/parse-cppcheck-logfile.sh" \
-          zephyrdoom-cppcheck-${{ github.run_number }}.log
+          cppcheck-${{ github.run_number }}.log
 
-      - name: Upload zephyrdoom logs
+      - name: Upload cppcheck logs
         uses: actions/upload-artifact@v4
         with:
-          name: zephyrdoom-cppcheck-${{ github.run_number }}
+          name: cppcheck-${{ github.run_number }}
           path: |
-            zephyrdoom-cppcheck-${{ github.run_number }}.log
-            zephyrdoom-cppcheck-${{ github.run_number }}-summary.log
+            cppcheck-${{ github.run_number }}.log
+            cppcheck-${{ github.run_number }}-summary.log

--- a/.github/workflows/pre-commit-verification.yml
+++ b/.github/workflows/pre-commit-verification.yml
@@ -1,5 +1,5 @@
 ---
-name: Pre-commit checks
+name: Pre-commit verification
 run-name: >
   ${{ github.workflow }} — Triggered by
   ${{ github.actor }} on ${{ github.ref_name }}
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   pre-commit-check:
-    name: Run pre-commit checks
+    name: Run Pre-commit verification
     runs-on: ubuntu-24.04
     if: github.ref_name != 'master' && github.ref_name != 'main'
 
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y \
           pre-commit
 
-      - name: Run pre-commit checks
+      - name: Run pre-commit command
         run: |
           pre-commit run \
           --verbose \

--- a/.github/workflows/release-repository.yml
+++ b/.github/workflows/release-repository.yml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y \
           zip
 
-      - name: Create ZIP archive of repository
+      - name: Create ZIP archive of the repository
         run: |
           zip -v -r \
           zephyr-doom-${{ github.event.inputs.tag }}.zip \

--- a/.github/workflows/shellcheck-verification.yml
+++ b/.github/workflows/shellcheck-verification.yml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   shellcheck-verification:
-    name: Run shellcheck verification
+    name: Run ShellCheck verification
     runs-on: ubuntu-24.04
 
     steps:
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y \
           shellcheck
 
-      - name: Run shellcheck verification
+      - name: Run shellcheck command
         run: |
           find . -type f -name "*.sh" | xargs shellcheck --shell=bash \
           2>&1 | tee shellcheck-${{ github.run_number }}.log


### PR DESCRIPTION
Earlier, the workflows due to unknown at the beginning structure had their own naming schema. As the number of them grew over the time, we could establish a pattern.

Thus:
- The file names have been unified accordingly;
- Change "check/lint" word to "verification" for clarity;
- Simplify file names of logs and compilation files as they are strictly related to the repository itself and there are no other choices that we should distingush;