### PR TITLE
Updates required to enable flashing of embedded target from devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -53,6 +53,12 @@ RUN curl https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/execu
     -o /usr/local/bin/nrfutil && \
     chmod +x /usr/local/bin/nrfutil
 
+# Install nRF command line tools for backward compatibility
+RUN curl https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-10-x-x/10-24-2/nrf-command-line-tools_10.24.2_amd64.deb \
+    -o /tmp/nrf-command-line-tools_10.24.2_amd64.deb && \
+    sudo apt-get -y install /tmp/nrf-command-line-tools_10.24.2_amd64.deb && \
+    rm -rf /tmp/nrf-command-line-tools_10.24.2_amd64.deb
+
 # Set the timezone to CET
 RUN ln -sf /usr/share/zoneinfo/CET /etc/localtime && \
     echo "CET" > /etc/timezone

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,33 +14,30 @@
         "setup-nRF-env.sh": "bash ${containerWorkspaceFolder}/.devcontainer/scripts/setup-nRF-env.sh"
     },
     "containerEnv": {
-        "ZEPHYR_BASE": "$HOME/ncs/v2.6.0/zephyr"
+        "ZEPHYR_BASE": "/home/developer/ncs/v2.6.0/zephyr"
     },
+    "mounts": [
+        "type=bind,source=/dev,target=/dev"
+    ],
     "runArgs": [
+        "--privileged",
         "--hostname",
         "zephyr-doom",
         "--env-file",
         "${localWorkspaceFolder}/.devcontainer/git.env"
-        "--volume",
-        "/dev/:/dev/,
-        "--volume",
-        "/${localWorkspaceFolder}/.devcontainer/JLink_Linux_V794e_x86_64.deb/:/home/developer/JLink_Linux_V794e_x86_64.deb/",
-        "--volume",
-        "/${localWorkspaceFolder}/.devcontainer/nrf-command-line-tools_10.24.2_amd64.deb/:/home/developer/nrf-command-line-tools_10.24.2_amd64.deb",
-        "--privileged"
     ],
     "customizations": {
         "vscode": {
             "extensions": [
-                "asciidoctor.asciidoctor-vscode@3.4.2",
+                "asciidoctor.asciidoctor-vscode@3.4.4",
                 "editorconfig.editorconfig@0.17.4",
-                "github.copilot@1.336.0",
+                "github.copilot@1.350.0",
                 "github.vscode-github-actions@0.27.2",
-                "ms-vscode.cmake-tools@1.20.53",
-                "ms-vscode.cpptools@1.25.3",
+                "ms-vscode.cmake-tools@1.21.36",
+                "ms-vscode.cpptools@1.26.3",
                 "ms-vscode.makefile-tools@0.12.17",
                 "nordic-semiconductor.nrf-connect-extension-pack@2025.4.4",
-                "timonwong.shellcheck@0.37.7",
+                "timonwong.shellcheck@0.38.3",
                 "tyriar.sort-lines@1.12.0"
             ],
             "settings": {

--- a/.devcontainer/scripts/setup-nRF-env.sh
+++ b/.devcontainer/scripts/setup-nRF-env.sh
@@ -4,26 +4,29 @@ set -euo pipefail
 
 TOOLCHAIN_VERSION=v2.6.2
 SDK_VERSION=v2.6.0
+JLINK_PKG_NAME="JLink_Linux_V794e_x86_64.deb"
 
 SDK_DIR_PATH="$HOME/ncs/$SDK_VERSION"
-
-# Install Segger JLink
-sudo dpkg --unpack /home/developer/JLink_Linux_V794e_x86_64.deb
-sudo rm /var/lib/dpkg/info/jlink.postinst -f
-sudo dpkg --force-all --configure jlink
-
-# Install nRF command line tools
-sudo dpkg -i /home/developer/nrf-command-line-tools_10.24.2_amd64.deb 
+JLINK_PKG_PATH="/workspaces/zephyr-doom/.devcontainer/${JLINK_PKG_NAME}"
+DPKG_INFO_PATH="/var/lib/dpkg/info"
 
 # Install nRF toolchain and SDK
 if [[ ! -d "$SDK_DIR_PATH" ||
-      -z $(ls -A "$SDK_DIR_PATH") ]]; then          
+      -z $(ls -A "$SDK_DIR_PATH") ]]; then
     nrfutil self-upgrade
     nrfutil install device
     nrfutil install toolchain-manager
     nrfutil toolchain-manager install --ncs-version "$TOOLCHAIN_VERSION"
     nrfutil install sdk-manager
     nrfutil sdk-manager install "$SDK_VERSION"
+fi
+
+# Install SEGGER J-Link
+if ! dpkg -s jlink &>/dev/null; then
+  sudo dpkg --unpack "$JLINK_PKG_PATH"
+  sudo rm -f "${DPKG_INFO_PATH}/jlink.postinst"
+  sudo dpkg --force-all --configure jlink
+  sudo apt-get -y install -f
 fi
 
 echo "Finished execution of $(basename "${0}") ..."

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Environment files
 *.env
 *.gitconfig
+*.deb
 
 # Documentation files
 *.html

--- a/docs/devcontainer.adoc
+++ b/docs/devcontainer.adoc
@@ -88,6 +88,13 @@ to the <<additional-config, Additional configuration>> chapter.
 
 === Additional configuration [[additional-config]]
 
+Due to licensing restrictions of the
+https://www.segger.com/downloads/jlink/[SEGGER J-Link] tool, the installation
+package must be downloaded manually and placed in the `.devcontainer` directory.
+
+NOTE: Make sure to download version `794e` of the package, as it is required for
+compatibility with this project's configuration.
+
 Helper extensions that could be installed:
 
 * https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-containers[Container Tools Extension]


### PR DESCRIPTION
- changes required to expose USB devices to container
- added Install Segger JLink to enable flashing of embedded target
- added Install nRF command line tools to enable flashing of embedded target